### PR TITLE
Corrected the example for removal prevention

### DIFF
--- a/user.py
+++ b/user.py
@@ -63,7 +63,7 @@ class User:
                 'name': 'Advanced Stuff',
                 'items': [
                     '-Remove Item',
-                    '!!Prevent Item Getting Removed',
+                    'Prevent Item Getting Removed!!',
                     '~Reference Another Activity'
                 ]
             },


### PR DESCRIPTION
Corrects the example for removal prevention to use the suffix form.